### PR TITLE
Nettoyage du rôle argo-provisioning-project

### DIFF
--- a/provisionning-project/roles/argo-provisioning-project/README.md
+++ b/provisionning-project/roles/argo-provisioning-project/README.md
@@ -1,0 +1,32 @@
+# argo-provisioning-project
+
+This role creates ArgoCD-operator-based `AppProject` objects.
+
+## Usage
+
+```yaml
+- hosts: localhost
+  become: false
+  gather_facts: false
+
+  roles:
+  - role: argo-provisioning-project
+
+  vars:
+    ENV_LIST:
+    - dev
+    - staging
+    - production
+
+    GITLAB_USER: myminion
+    GITLAB_TOKEN: glpat-v2hPsNobbR8v2s189b2F
+
+    GITLAB_URL: https://gitlab.myorg.com
+    GITLAB_PROJECT_PATH: "{{ GITLAB_URL }}/myorg/myproject/mygitops.git"
+
+    NAMESPACE_NAME: my-project
+
+    # Use existing kubeconfig
+    override_kubeconfig: false # Default value, use 'true' at your own risk
+    K8S_AUTH_KUBECONFIG: {}
+```

--- a/provisionning-project/roles/argo-provisioning-project/defaults/main.yml
+++ b/provisionning-project/roles/argo-provisioning-project/defaults/main.yml
@@ -1,3 +1,4 @@
+override_kubeconfig: false
 NAMESPACE_NAME: "{{ ORGANIZATION_NAME }}-{{ PROJECT_NAME }}"
 ENV_LIST: ["dev"]
 GITLAB_URL: https://gitlab.example.com/

--- a/provisionning-project/roles/argo-provisioning-project/tasks/argo_install.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/argo_install.yml
@@ -1,0 +1,4 @@
+- name: Install | Create argo project
+  kubernetes.core.k8s:
+    state: present
+    template: ./templates/argo_project.yml.j2

--- a/provisionning-project/roles/argo-provisioning-project/tasks/argo_post_install.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/argo_post_install.yml
@@ -1,0 +1,4 @@
+- name: Post-Install | Removing kubeconfig
+  file:
+    path: "~/.kube/config"
+    state: absent

--- a/provisionning-project/roles/argo-provisioning-project/tasks/argo_post_install.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/argo_post_install.yml
@@ -1,4 +1,5 @@
 - name: Post-Install | Removing kubeconfig
+  when: override_kubeconfig is true or override_kubeconfig is false and override_kubeconfig.stat.exists is false
   file:
     path: "~/.kube/config"
     state: absent

--- a/provisionning-project/roles/argo-provisioning-project/tasks/argo_pre_install.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/argo_pre_install.yml
@@ -1,0 +1,10 @@
+- name: Pre-Install | Get kubeconfig facts
+  register: kubeconfig_stat
+  stat:
+    path: "~/.kube/config"
+
+- name: Pre-Install | Creating kubeconfig
+  when: override_kubeconfig is true or override_kubeconfig is false and override_kubeconfig.stat.exists it false
+  copy:
+    dest: "~/.kube/config"
+    content: "{{lookup('vars','K8S_AUTH_KUBECONFIG')}}"

--- a/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
@@ -1,9 +1,45 @@
-- name: Creating kubeconfig
-  copy:
-    dest: "~/.kube/config"
-    content: "{{lookup('vars','K8S_AUTH_KUBECONFIG')}}"
+- name: Assert | Check project path
+  assert:
+    fail_msg: GITLAB_PROJECT_PATH must be a valid URL
+    that:
+    - GITLAB_PROJECT_PATH is defined
+    - GITLAB_PROJECT_PATH | length > 0
 
-- name: Create argo project
-  kubernetes.core.k8s:
-    state: present
-    template: ./templates/argo_project.yml.j2
+- name: Assert | Check token
+  assert:
+    fail_msg: GITLAB_TOKEN is not valid
+    that:
+    - GITLAB_TOKEN is defined
+    - GITLAB_TOKEN | regex_search("^.+?$") | length > 0
+
+- name: Assert | Check user
+  assert:
+    fail_msg: GITLAB_USER is not valid
+    that:
+    - GITLAB_USER is defined
+    - GITLAB_USER | length > 0
+
+- name: Assert | Check namespace
+  assert:
+    fail_msg: NAMESPACE_NAME must be a valid name
+    that:
+    - NAMESPACE_NAME is defined
+    - NAMESPACE_NAME | length > 0
+
+- name: Assert | Check kubeconfig
+  assert:
+    fail_msg: K8S_AUTH_KUBECONFIG is not valid
+    that:
+    - K8S_AUTH_KUBECONFIG is defined
+    - K8S_AUTH_KUBECONFIG is dict
+
+- name: Assert | Check override_kubeconfig
+  assert:
+    fail_msg: override_kubeconfig must be valid
+    that:
+    - override_kubeconfig is defined
+    - override_kubeconfig is boolean
+
+- include_tasks: argo_pre_install.yml
+- include_tasks: argo_install.yml
+- include_tasks: argo_post_install.yml

--- a/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
@@ -10,7 +10,7 @@
     fail_msg: GITLAB_TOKEN is not valid
     that:
     - GITLAB_TOKEN is defined
-    - GITLAB_TOKEN | regex_search("^.+?$") | length > 0
+    - GITLAB_TOKEN | regex_search("^glpat-.{20}$") | length == 26
 
 - name: Assert | Check user
   assert:

--- a/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
+++ b/provisionning-project/roles/argo-provisioning-project/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: Assert | Check Gitlab's URL
+  assert:
+    fail_msg: GITLAB_URL must be a valid URL
+    that:
+    - GITLAB_URL is defined
+    - (GITLAB_URL | urlsplit)['hostname'] != ""
+
 - name: Assert | Check project path
   assert:
     fail_msg: GITLAB_PROJECT_PATH must be a valid URL
@@ -10,7 +17,7 @@
     fail_msg: GITLAB_TOKEN is not valid
     that:
     - GITLAB_TOKEN is defined
-    - GITLAB_TOKEN | regex_search("^glpat-.{20}$") | length == 26
+    - GITLAB_TOKEN | regex_search("^glpat-[A-Za-z0-9]{20}$") | length == 26
 
 - name: Assert | Check user
   assert:


### PR DESCRIPTION
Le rôle a été découpé en fonction des actions selon un modèle classique (fichier principal avec tests des variables d'entrée, pré-installation, installation, post-installation).

Un fichier `README.md` a été ajouté afin d'expliquer à minima son usage.

Un mécanisme de sécurisation du fichier de configuration de client Kubernetes a été ajouté afin de ne pas le supprimer sauvagement et ainsi perdre l'accès au cluster.

En lien avec #2 et #8 